### PR TITLE
Wijzigen van een link tekst is niet mogelijk

### DIFF
--- a/test/unit/vl-proza-message.test.html
+++ b/test/unit/vl-proza-message.test.html
@@ -97,10 +97,10 @@
             return fetchMock.flush(true).then(() => {
                 const message = element.querySelector('#message-1');
                 const button = prozaMessageEditButton(message);
- 				window.addEventListener('beforeunload', function(event) {
-					throw new Error("Link mag niet gevolgd worden");
-      			});
-		        return button.click();
+                window.addEventListener('beforeunload', function(event) {
+                    throw new Error("Link mag niet gevolgd worden");
+		});
+                return button.click();
             });
         });
 

--- a/test/unit/vl-proza-message.test.html
+++ b/test/unit/vl-proza-message.test.html
@@ -36,7 +36,16 @@
     </template>
 </test-fixture>
 
+<test-fixture id="vl-proza-message-inside-link">
+    <template>
+        <a href="http://www.google.be">
+            <vl-proza-message id="message-1" data-vl-domain="foo" data-vl-code="bar"></vl-proza-message>
+        </button>
+    </template>
+</test-fixture>
+
 <script type="module">
+
     import {VlProzaMessage, VlProzaMessagePreloader} from '../../vl-proza-message.src.js';
     import {awaitUntil} from 'vl-ui-core/vl-core';
     import fetchMock from 'fetch-mock/esm/client.mjs';
@@ -82,6 +91,19 @@
         function prozaTypographyElement(message) {
             return message.querySelector('vl-typography');
         }
+
+        test('de default behavior van het klikken op de bewerk knop binnen een link wordt gestopt', () => {
+            const element = fixture('vl-proza-message-inside-link');
+            return fetchMock.flush(true).then(() => {
+                const message = element.querySelector('#message-1');
+                const button = prozaMessageEditButton(message);
+ 				window.addEventListener('beforeunload', function(event) {
+					throw new Error("Link mag niet gevolgd worden");
+      			});
+		        return button.click();
+            });
+        });
+
 
         test('toont een bericht', () => {
             const proza = fixture('vl-proza-messages-fixture');
@@ -450,6 +472,7 @@
                 });
             });
         });
+
     });
 </script>
 </body>

--- a/vl-proza-message.src.js
+++ b/vl-proza-message.src.js
@@ -225,6 +225,7 @@ export class VlProzaMessage extends VlElement(HTMLElement) {
 
     __initWysiwyg(event) {
         event.stopPropagation();
+        event.preventDefault();
         this.__unwrapWysiwygElement();
         tinyMCE.baseURL = '/node_modules/tinymce';
         this.__hideWysiwygButton();


### PR DESCRIPTION
Wanneer de tekst van een link gewijzigd wordt, zal bij het klikken een redirect gebeuren naar de achterliggende link. Prevent default behavior van klikken op potloodje.